### PR TITLE
Added the ValueToArrayInterface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the `digipolisgent/value` package.
 
+## [Unreleased]
+
+### Added
+
+- Added the ValueToArrayInterface.
+
 ## [1.0.0]
 
 ### Added

--- a/src/ValueToArrayInterface.php
+++ b/src/ValueToArrayInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DigipolisGent\Value;
+
+/**
+ * Interface adding the possibility to get an array representation of the value.
+ *
+ * @package DigipolisGent\Value
+ */
+interface ValueToArrayInterface
+{
+    /**
+     * Returns a value object based on values extracted from the given array.
+     *
+     * @return array
+     *   The data array representing the value object.
+     */
+    public static function toArray();
+}


### PR DESCRIPTION
Added interface to add toArray() method to value objects.

## Description

Objects needs sometimes to be serialised or converted to json. The simplest way to do this in PHP is by "normalising" the object into an array structure.

The preferred array structure is one that can be converted back into an object by the fromArray() method (see `ValueFromArrayInterface`).

## Motivation and Context

The interface allows consumers of the value objects to check if the toArray() method is available.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Documentation update.
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG accordingly.
- [x] I have read the **CONTRIBUTING** document.
